### PR TITLE
allow specifying touch identifiers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,10 @@ function createTouchList(target, list) {
         list = [list];
     }
     list = list.map(function (entry, index) {
-        return createTouch(entry[0], entry[1], target, index + 1);
+        var x = entry[0];
+        var y = entry[1];
+        var id = entry[2] ? entry[2] : index + 1;
+        return createTouch(x, y, target, id);
     });
     return document.createTouchList.apply(document, list);
 }


### PR DESCRIPTION
This commit makes it possible to specify touch identifiers. 

Use like this:

```
var touchStart = createTouchEvent(elem, "touchstart", [[100, 80, 0], [150, 150, 1], [65, 275, 2]]),
    touchEnd1 = createTouchEvent(elem, "touchend", [[65 , 275 , 2]]),
    touchEnd2 = createTouchEvent(elem, "touchend", [[150 , 150 , 1]]),
    touchEnd3 = createTouchEvent(elem, "touchend", [[100 , 80 , 0]]);
```
