### PR TITLE
Fix bug when using 0 as touch identifier

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ function createTouchList(target, list) {
     list = list.map(function (entry, index) {
         var x = entry[0];
         var y = entry[1];
-        var id = entry[2] ? entry[2] : index + 1;
+        var id = entry[2] || index;
         return createTouch(x, y, target, id);
     });
     return document.createTouchList.apply(document, list);
@@ -60,7 +60,7 @@ function createTouchList(target, list) {
 function createTouch(x, y, target, id) {
     return document.createTouch(window, target,
         //identifier
-        id || 1,
+        id || 0,
         //pageX / clientX
         x,
         //pageY / clientY


### PR DESCRIPTION
`0` is a falsey value, thus the identifier will incorrectly be
changed to `1` in current implementation.
This commit fixes that by defaulting the touch identifier to index,
instead of index+1.
This is possibly a breaking change, if mocked touch events without
explicitly set identifiers expect to start from 1.